### PR TITLE
Removed AVX2 Dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16.3)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_C_FLAGS_RELEASE "-static -O3 -fPIE -ftree-vectorize")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -m64 -O3 -pthread -Wall -Wuninitialized -fprefetch-loop-arrays -funroll-all-loops -ftree-vectorize -march=x86-64-v3")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -m64 -O3 -pthread -Wall -Wuninitialized -fprefetch-loop-arrays -funroll-all-loops -ftree-vectorize")
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER g++)

--- a/src/astrobwtv3/astrobwtv3.cpp
+++ b/src/astrobwtv3/astrobwtv3.cpp
@@ -10873,8 +10873,30 @@ void lookupCompute(workerData &worker)
         // Manually unrolled loops for repetetive efficiency. Worst possible loop count for 3D
         // lookups is now 4, with less than 4 being pretty common.
 
+        // Groups of 16
+        for(int i = worker.pos1; i < worker.pos2-15; i += 16) {
+          __builtin_prefetch(&lookup3D[firstIndex + 64*n++],0,3);
+          worker.step_3[i] = lookup3D[firstIndex + worker.step_3[i]];
+          worker.step_3[i+1] = lookup3D[firstIndex + worker.step_3[i+1]];
+          worker.step_3[i+2] = lookup3D[firstIndex + worker.step_3[i+2]];
+          worker.step_3[i+3] = lookup3D[firstIndex + worker.step_3[i+3]];
+          worker.step_3[i+4] = lookup3D[firstIndex + worker.step_3[i+4]];
+          worker.step_3[i+5] = lookup3D[firstIndex + worker.step_3[i+5]];
+          worker.step_3[i+6] = lookup3D[firstIndex + worker.step_3[i+6]];
+          worker.step_3[i+7] = lookup3D[firstIndex + worker.step_3[i+7]];
+
+          worker.step_3[i+8] = lookup3D[firstIndex + worker.step_3[i+8]];
+          worker.step_3[i+9] = lookup3D[firstIndex + worker.step_3[i+9]];
+          worker.step_3[i+10] = lookup3D[firstIndex + worker.step_3[i+10]];
+          worker.step_3[i+11] = lookup3D[firstIndex + worker.step_3[i+11]];
+          worker.step_3[i+12] = lookup3D[firstIndex + worker.step_3[i+12]];
+          worker.step_3[i+13] = lookup3D[firstIndex + worker.step_3[i+13]];
+          worker.step_3[i+14] = lookup3D[firstIndex + worker.step_3[i+14]];
+          worker.step_3[i+15] = lookup3D[firstIndex + worker.step_3[i+15]];
+        }
+
         // Groups of 8
-        for(int i = worker.pos1; i < worker.pos2-7; i += 8) {
+        for(int i = worker.pos2-((worker.pos2-worker.pos1)%16); i < worker.pos2-7; i += 8) {
           __builtin_prefetch(&lookup3D[firstIndex + 64*n++],0,3);
           worker.step_3[i] = lookup3D[firstIndex + worker.step_3[i]];
           worker.step_3[i+1] = lookup3D[firstIndex + worker.step_3[i+1]];

--- a/src/astrobwtv3/astrobwtv3.cpp
+++ b/src/astrobwtv3/astrobwtv3.cpp
@@ -128,7 +128,7 @@ void checkSIMDSupport() {
 }
 */
 
-
+#if defined(__AVX2__)
 inline __m128i mullo_epi8(__m128i a, __m128i b)
 {
     // unpack and multiply
@@ -385,6 +385,8 @@ inline __m256i _mm256_reverse_epi8(__m256i input) {
 
     return input;
 }
+
+#endif
 
 void optest(int op, workerData &worker, bool print=true) {
   if (print) {
@@ -3574,7 +3576,10 @@ void optest_lookup(int op, workerData &worker, bool print=true) {
 }
 
 void runOpTests(int op, int len) {
+  #if defined(__AVX2__)
   testPopcnt256_epi8();
+  #endif
+
   workerData *worker = (workerData*)malloc_huge_pages(sizeof(workerData));
   initWorker(*worker);
   lookupGen(*worker, lookup2D, lookup3D);
@@ -3980,6 +3985,8 @@ void TestAstroBWTv3repeattest()
   std::cout << "Repeated test over" << std::endl;
 }
 
+#if defined(__AVX2__)
+
 void computeByteFrequencyAVX2(const unsigned char* data, size_t dataSize, int frequencyTable[256]) {
     __m256i chunk;
     const size_t simdWidth = 32; // AVX2 SIMD register width in bytes
@@ -4013,6 +4020,8 @@ void computeByteFrequencyAVX2(const unsigned char* data, size_t dataSize, int fr
         frequencyTable[i] += localFrequencyTable[i];
     }
 }
+
+#endif
 
 
 void AstroBWTv3(byte *input, int inputLen, byte *outputhash, workerData &worker, bool lookupMine, bool simd)
@@ -4121,6 +4130,7 @@ void AstroBWTv3(byte *input, int inputLen, byte *outputhash, workerData &worker,
     std::cerr << ex.what() << std::endl;
   }
 }
+
 
 void branchComputeCPU(workerData &worker)
 {
@@ -7315,6 +7325,8 @@ void branchComputeCPU(workerData &worker)
     }
   }
 }
+
+#if defined(__AVX2__)
 
 void branchComputeCPU_optimized(workerData &worker)
 {
@@ -10749,6 +10761,8 @@ void branchComputeCPU_optimized(workerData &worker)
     }
   }
 }
+
+#endif
 
 // Compute the new values for worker.step_3 using layered lookup tables instead of
 // branched computational operations

--- a/src/miner/miner.cpp
+++ b/src/miner/miner.cpp
@@ -100,8 +100,8 @@ uint16_t *lookup2D_global; // Storage for computed values of 2-byte chunks
 byte *lookup3D_global; // Storage for deterministically computed values of 1-byte chunks
 
 int jobCounter;
-boost::atomic<int64_t> counter = 0;
-boost::atomic<int64_t> benchCounter = 0;
+std::atomic<int64_t> counter = 0;
+std::atomic<int64_t> benchCounter = 0;
 
 int blockCounter;
 int miniBlockCounter;
@@ -1205,8 +1205,8 @@ void benchmark(int tid)
       }
       AstroBWTv3(work, MINIBLOCK_SIZE, powHash, *worker, true, false);
 
-      counter.store(counter + 1);
-      benchCounter.store(benchCounter + 1);
+      counter.fetch_add(1);
+      benchCounter.fetch_add(1);
       if (stopBenchmark)
         break;
     }
@@ -1316,7 +1316,7 @@ waitForJob:
         }
         AstroBWTv3(&WORK[0], MINIBLOCK_SIZE, powHash, *worker, true, false);
         
-        counter.store(counter + 1);
+        counter.fetch_add(1);
         submit = devMine ? !submittingDev : !submitting;
         if (submit && CheckHash(powHash, cmpDiff))
         {


### PR DESCRIPTION
Should now compile easily without the -march=x86-64-v3 flag, and run on legacy systems as before.