### PR TITLE
Add global maskTable. Disable clang optimizations when initializing it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,16 +64,19 @@ jobs:
         cmake ..
         make -j$(nproc)
         tar -zcvf ../tnn-miner.tar.gz Tnn-miner
-    - name: Release
+    - name: 'Archive tnn-miner.tar.gz'
+      uses: actions/upload-artifact@v4
+      with:
+        name: tnn-miner.tar.gz
+        path: ./tnn-miner.tar.gz
+        retention-days: 5
+    - name: 'Test Tnn-miner'
+      run: |
+        ./build/Tnn-miner --test
+    - name: 'Release'
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         make_latest: "true"
         files: |
           tnn-miner.tar.gz
-    - name: Archive tnn-miner.tar.gz
-      uses: actions/upload-artifact@v4
-      with:
-        name: tnn-miner.tar.gz
-        path: ./tnn-miner.tar.gz
-        retention-days: 5

--- a/src/astrobwtv3/astrobwtv3.cpp
+++ b/src/astrobwtv3/astrobwtv3.cpp
@@ -3534,7 +3534,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rolv_epi8(data, data);
 
           // Write results to workerData
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         if ((worker.pos2-worker.pos1)%2 == 1) {
@@ -3555,7 +3555,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_add_epi8(data, data);;
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3574,7 +3574,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           pop = popcnt256_epi8(data);
           data = _mm256_xor_si256(data,pop);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3587,7 +3587,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data,_mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_rol_epi8(data,1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3601,7 +3601,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rolv_epi8(data,data);
           data = _mm256_sub_epi8(data,_mm256_xor_si256(data,_mm256_set1_epi8(97)));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3617,7 +3617,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_sllv_epi8(data,_mm256_and_si256(data,vec_3));
           data = _mm256_srlv_epi8(data,_mm256_and_si256(data,vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         
@@ -3634,7 +3634,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           __m256i x = _mm256_xor_si256(data,_mm256_set1_epi8(97));
           data = _mm256_sub_epi8(data,x);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3650,7 +3650,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data,pop);
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3663,7 +3663,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data,2);
           data = _mm256_sllv_epi8(data,_mm256_and_si256(data,vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3677,7 +3677,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data,2));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3691,7 +3691,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 3);
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3704,7 +3704,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data,_mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_rolv_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3718,7 +3718,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data,2));
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3732,7 +3732,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data,_mm256_and_si256(data,vec_3));
           data = _mm256_rol_epi8(data, 5);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3746,7 +3746,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_mul_epi8(data, data);
           data = _mm256_sllv_epi8(data,_mm256_and_si256(data,vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3760,7 +3760,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_sub_epi8(data,_mm256_xor_si256(data,_mm256_set1_epi8(97)));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3774,7 +3774,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data,1);
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3788,7 +3788,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data,5);
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3799,7 +3799,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
 
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_rol_epi8(data, 1);
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3813,7 +3813,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_sllv_epi8(data,_mm256_and_si256(data,vec_3));
           data = _mm256_add_epi8(data, data);;;
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3827,7 +3827,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3842,7 +3842,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_add_epi8(data, data);
           data = _mm256_and_si256(data,_mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
     break;
@@ -3856,7 +3856,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_mul_epi8(data,data);
           data = _mm256_rol_epi8(data,1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3869,7 +3869,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data,popcnt256_epi8(data));
           data = _mm256_and_si256(data,_mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
       break;
@@ -3883,7 +3883,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_rol_epi8(data, 5);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3909,7 +3909,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_add_epi8(data, data);
           data = _mm256_reverse_epi8(data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3922,7 +3922,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data,_mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_rol_epi8(data, 5);
-          if (worker.pos2-i < 32) data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          if (worker.pos2-i < 32) data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3936,7 +3936,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_add_epi8(data, data);
           data = _mm256_rol_epi8(data, 5);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3950,7 +3950,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_add_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3964,7 +3964,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 5);
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data,vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3978,7 +3978,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -3992,7 +3992,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 3);
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4006,7 +4006,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4020,7 +4020,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_sub_epi8(data, _mm256_xor_si256(data, _mm256_set1_epi8(97)));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4034,7 +4034,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 1);
           data = _mm256_xor_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4048,7 +4048,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
           data = _mm256_rol_epi8(data, 1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4062,7 +4062,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4088,7 +4088,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data,vec_3));
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4102,7 +4102,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, popcnt256_epi8(data));
           data = _mm256_xor_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4116,7 +4116,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 3);
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4129,7 +4129,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
           data = _mm256_rolv_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4143,7 +4143,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_sub_epi8(data, _mm256_xor_si256(data, _mm256_set1_epi8(97)));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4168,7 +4168,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_xor_si256(data, popcnt256_epi8(data));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4182,7 +4182,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 5);
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4196,7 +4196,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 5);
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data,vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4208,7 +4208,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rolv_epi8(data, data);
           data = _mm256_rol_epi8(data, 5);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4222,7 +4222,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4236,7 +4236,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_add_epi8(data, data);
           data = _mm256_rol_epi8(data, 1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4262,7 +4262,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
           data = _mm256_xor_si256(data, popcnt256_epi8(data));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4286,7 +4286,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_xor_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
 
@@ -4313,7 +4313,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
           data = _mm256_rol_epi8(data, 1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4325,7 +4325,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rolv_epi8(data, data);
           data = _mm256_reverse_epi8(data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4339,7 +4339,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_add_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }  
         break;
@@ -4353,7 +4353,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rolv_epi8(data, data);
           data = _mm256_xor_si256(data, _mm256_set1_epi64x(-1LL));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4370,7 +4370,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4384,7 +4384,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 5);
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data, vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4398,7 +4398,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
           data = _mm256_add_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4412,7 +4412,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_sub_epi8(data, _mm256_xor_si256(data, _mm256_set1_epi8(97)));
           data = _mm256_add_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
 
@@ -4427,7 +4427,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4440,7 +4440,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
           data = _mm256_mul_epi8(data, data);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4454,7 +4454,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_rol_epi8(data, 1);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4468,7 +4468,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 2));
           data = _mm256_rol_epi8(data, 5);
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4482,7 +4482,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_xor_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4496,7 +4496,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data, vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4510,7 +4510,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_srlv_epi8(data, _mm256_and_si256(data, vec_3));
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4524,7 +4524,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_mul_epi8(data, data);
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data, vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4538,7 +4538,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_xor_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_sllv_epi8(data, _mm256_and_si256(data, vec_3));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4552,7 +4552,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_rol_epi8(data, 5);
           data = _mm256_sub_epi8(data, _mm256_xor_si256(data, _mm256_set1_epi8(97)));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4566,7 +4566,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_reverse_epi8(data);
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4580,7 +4580,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
           data = _mm256_and_si256(data, _mm256_set1_epi8(worker.step_3[worker.pos2]));
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
 
-          data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
         }
         break;
@@ -4597,7 +4597,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4615,7 +4615,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4633,7 +4633,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4651,7 +4651,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4669,7 +4669,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4687,7 +4687,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4703,7 +4703,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4721,7 +4721,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4739,7 +4739,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4757,7 +4757,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4775,7 +4775,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4793,7 +4793,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4811,7 +4811,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4829,7 +4829,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4846,7 +4846,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4864,7 +4864,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4882,7 +4882,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4900,7 +4900,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4918,7 +4918,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4935,7 +4935,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4965,7 +4965,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -4983,7 +4983,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5001,7 +5001,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5019,7 +5019,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5037,7 +5037,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5055,7 +5055,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5073,7 +5073,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5091,7 +5091,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5109,7 +5109,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5127,7 +5127,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5144,7 +5144,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5162,7 +5162,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5180,7 +5180,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5198,7 +5198,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5216,7 +5216,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5234,7 +5234,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5251,7 +5251,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5269,7 +5269,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5287,7 +5287,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5305,7 +5305,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5323,7 +5323,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5341,7 +5341,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5359,7 +5359,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5377,7 +5377,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5396,7 +5396,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5414,7 +5414,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5431,7 +5431,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5449,7 +5449,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5467,7 +5467,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5483,7 +5483,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5501,7 +5501,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5533,7 +5533,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5551,7 +5551,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5570,7 +5570,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5588,7 +5588,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5606,7 +5606,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5624,7 +5624,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5642,7 +5642,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5660,7 +5660,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5678,7 +5678,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5696,7 +5696,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5712,7 +5712,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5730,7 +5730,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5749,7 +5749,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5767,7 +5767,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5785,7 +5785,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5803,7 +5803,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5821,7 +5821,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5840,7 +5840,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5858,7 +5858,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5876,7 +5876,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5894,7 +5894,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5912,7 +5912,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5930,7 +5930,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5948,7 +5948,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5963,7 +5963,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -5982,7 +5982,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6001,7 +6001,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6018,7 +6018,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6036,7 +6036,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6055,7 +6055,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6073,7 +6073,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6090,7 +6090,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6108,7 +6108,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6126,7 +6126,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6144,7 +6144,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6163,7 +6163,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6181,7 +6181,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6199,7 +6199,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6215,7 +6215,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6233,7 +6233,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6251,7 +6251,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6269,7 +6269,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6288,7 +6288,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6306,7 +6306,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6324,7 +6324,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6344,7 +6344,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6362,7 +6362,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6380,7 +6380,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6399,7 +6399,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6417,7 +6417,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6435,7 +6435,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6453,7 +6453,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6471,7 +6471,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6488,7 +6488,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6506,7 +6506,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6524,7 +6524,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6542,7 +6542,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6560,7 +6560,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6578,7 +6578,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6608,7 +6608,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6626,7 +6626,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6644,7 +6644,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6662,7 +6662,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6680,7 +6680,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6698,7 +6698,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6717,7 +6717,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6735,7 +6735,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6753,7 +6753,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6771,7 +6771,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6789,7 +6789,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6808,7 +6808,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6826,7 +6826,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6844,7 +6844,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6862,7 +6862,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6880,7 +6880,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6899,7 +6899,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6918,7 +6918,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6936,7 +6936,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6967,7 +6967,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -6985,7 +6985,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7003,7 +7003,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7021,7 +7021,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7039,7 +7039,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7057,7 +7057,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7075,7 +7075,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7093,7 +7093,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7111,7 +7111,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7129,7 +7129,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7147,7 +7147,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7165,7 +7165,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7183,7 +7183,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7201,7 +7201,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7219,7 +7219,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7236,7 +7236,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7254,7 +7254,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7272,7 +7272,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7290,7 +7290,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7309,7 +7309,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7328,7 +7328,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7346,7 +7346,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7364,7 +7364,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7382,7 +7382,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7402,7 +7402,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7420,7 +7420,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7438,7 +7438,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7456,7 +7456,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7474,7 +7474,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7492,7 +7492,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7509,7 +7509,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7527,7 +7527,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7546,7 +7546,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7564,7 +7564,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7583,7 +7583,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7601,7 +7601,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7619,7 +7619,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7637,7 +7637,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7655,7 +7655,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7674,7 +7674,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7705,7 +7705,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7724,7 +7724,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7742,7 +7742,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -7779,7 +7779,7 @@ void optest_simd(int op, workerData &worker, bool print=true) {
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.step_3[i], data);
           }
@@ -8215,7 +8215,7 @@ void TestAstroBWTv3()
   lookupGen(*worker, lookup2D, lookup3D);
   workerData *worker2 = (workerData *)malloc_huge_pages(sizeof(workerData));
   initWorker(*worker2);
-  lookupGen(*worker2, lookup2D, lookup3D);
+  //lookupGen(*worker2, lookup2D, lookup3D);
 
   int i = 0;
   for (PowTest t : random_pow_tests)
@@ -11821,7 +11821,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11847,7 +11847,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11870,7 +11870,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11887,7 +11887,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11905,7 +11905,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11925,7 +11925,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11946,7 +11946,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11966,7 +11966,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -11983,7 +11983,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12001,7 +12001,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12019,7 +12019,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12036,7 +12036,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12054,7 +12054,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12072,7 +12072,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12090,7 +12090,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12108,7 +12108,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12126,7 +12126,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12144,7 +12144,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12159,7 +12159,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12177,7 +12177,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12195,7 +12195,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12214,7 +12214,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12232,7 +12232,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12249,7 +12249,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12267,7 +12267,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12297,7 +12297,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12311,7 +12311,7 @@ void branchComputeCPU_avx2(workerData &worker)
           data = _mm256_and_si256(data,_mm256_set1_epi8(worker.chunk[worker.pos2]));
           data = _mm256_xor_si256(data, _mm256_rol_epi8(data, 4));
           data = _mm256_rol_epi8(data, 5);
-          if (worker.pos2-i < 32) data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+          if (worker.pos2-i < 32) data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
         break;
@@ -12328,7 +12328,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12346,7 +12346,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12364,7 +12364,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12382,7 +12382,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12400,7 +12400,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12418,7 +12418,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12436,7 +12436,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12454,7 +12454,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12472,7 +12472,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12490,7 +12490,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12520,7 +12520,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12538,7 +12538,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12556,7 +12556,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12573,7 +12573,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12591,7 +12591,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12620,7 +12620,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12638,7 +12638,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12656,7 +12656,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12672,7 +12672,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12690,7 +12690,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12708,7 +12708,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12738,7 +12738,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12766,7 +12766,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12797,7 +12797,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12813,7 +12813,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12831,7 +12831,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }  
@@ -12849,7 +12849,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12870,7 +12870,7 @@ void branchComputeCPU_avx2(workerData &worker)
                 #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
@@ -12888,7 +12888,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12906,7 +12906,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12924,7 +12924,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12943,7 +12943,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12960,7 +12960,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12978,7 +12978,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -12996,7 +12996,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13014,7 +13014,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13032,7 +13032,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13050,7 +13050,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13068,7 +13068,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13086,7 +13086,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13104,7 +13104,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13122,7 +13122,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13140,7 +13140,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
           _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
         }
@@ -13158,7 +13158,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13176,7 +13176,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13194,7 +13194,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13212,7 +13212,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13230,7 +13230,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13248,7 +13248,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13264,7 +13264,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13282,7 +13282,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13300,7 +13300,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13318,7 +13318,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13336,7 +13336,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13354,7 +13354,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13372,7 +13372,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13390,7 +13390,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13407,7 +13407,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13425,7 +13425,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13443,7 +13443,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13461,7 +13461,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13479,7 +13479,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13496,7 +13496,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13526,7 +13526,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13544,7 +13544,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13562,7 +13562,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13580,7 +13580,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13598,7 +13598,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13616,7 +13616,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13634,7 +13634,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13652,7 +13652,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13670,7 +13670,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13688,7 +13688,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13705,7 +13705,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13723,7 +13723,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13741,7 +13741,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13759,7 +13759,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13777,7 +13777,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13795,7 +13795,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13812,7 +13812,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13830,7 +13830,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13848,7 +13848,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13866,7 +13866,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13884,7 +13884,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13902,7 +13902,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13920,7 +13920,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13938,7 +13938,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13957,7 +13957,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13975,7 +13975,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -13992,7 +13992,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14010,7 +14010,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14028,7 +14028,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14044,7 +14044,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14062,7 +14062,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14094,7 +14094,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14112,7 +14112,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14131,7 +14131,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14149,7 +14149,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14167,7 +14167,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14185,7 +14185,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14203,7 +14203,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14221,7 +14221,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14239,7 +14239,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14257,7 +14257,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14273,7 +14273,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14291,7 +14291,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14310,7 +14310,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14328,7 +14328,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14346,7 +14346,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14364,7 +14364,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14382,7 +14382,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14401,7 +14401,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14419,7 +14419,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14437,7 +14437,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14455,7 +14455,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14473,7 +14473,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14491,7 +14491,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14509,7 +14509,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14524,7 +14524,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14543,7 +14543,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14562,7 +14562,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14579,7 +14579,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14597,7 +14597,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14616,7 +14616,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14634,7 +14634,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14651,7 +14651,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14669,7 +14669,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14687,7 +14687,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14705,7 +14705,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14724,7 +14724,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14742,7 +14742,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14760,7 +14760,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14776,7 +14776,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14794,7 +14794,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14812,7 +14812,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14830,7 +14830,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14849,7 +14849,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14867,7 +14867,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14885,7 +14885,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14905,7 +14905,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14923,7 +14923,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14941,7 +14941,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14960,7 +14960,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14978,7 +14978,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -14996,7 +14996,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15014,7 +15014,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15032,7 +15032,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15049,7 +15049,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15067,7 +15067,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15085,7 +15085,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15103,7 +15103,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15121,7 +15121,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15139,7 +15139,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15169,7 +15169,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15187,7 +15187,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15205,7 +15205,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15223,7 +15223,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15241,7 +15241,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15259,7 +15259,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15278,7 +15278,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15296,7 +15296,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15314,7 +15314,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15332,7 +15332,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15350,7 +15350,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15369,7 +15369,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15387,7 +15387,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15405,7 +15405,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15423,7 +15423,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15441,7 +15441,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15460,7 +15460,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15479,7 +15479,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15497,7 +15497,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15528,7 +15528,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15546,7 +15546,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15564,7 +15564,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15582,7 +15582,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15600,7 +15600,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15618,7 +15618,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15636,7 +15636,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15654,7 +15654,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15672,7 +15672,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15690,7 +15690,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15708,7 +15708,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15726,7 +15726,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15744,7 +15744,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15762,7 +15762,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15780,7 +15780,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15797,7 +15797,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15815,11 +15815,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              #ifdef _WIN32
-              data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
-            #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
-            #endif
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15837,7 +15833,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15855,7 +15851,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15874,7 +15870,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15893,7 +15889,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15911,7 +15907,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15929,7 +15925,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15947,7 +15943,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15967,7 +15963,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -15985,7 +15981,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16003,7 +15999,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16021,7 +16017,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16039,7 +16035,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16057,7 +16053,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16074,7 +16070,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16092,7 +16088,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16111,7 +16107,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16129,7 +16125,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16148,7 +16144,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16166,7 +16162,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16184,7 +16180,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16202,7 +16198,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16220,7 +16216,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16239,7 +16235,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16270,7 +16266,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16289,7 +16285,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16307,7 +16303,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }
@@ -16347,7 +16343,7 @@ void branchComputeCPU_avx2(workerData &worker)
             #ifdef _WIN32
               data = _mm256_blendv_epi8(old, data, worker.maskTable[worker.pos2-i]);
             #else
-              data = _mm256_blendv_epi8(old, data, _mm256_loadu_si256((__m256i*)&worker.maskTable[worker.pos2-i]));
+              data = _mm256_blendv_epi8(old, data, g_maskTable[worker.pos2-i]);
             #endif
             _mm256_storeu_si256((__m256i*)&worker.chunk[i], data);
           }

--- a/src/astrobwtv3/pow.h
+++ b/src/astrobwtv3/pow.h
@@ -62,7 +62,9 @@ const int AMASK	= (1<<ABIT)-1;
 
 #endif
 
-
+#if defined(__AVX2__)
+alignas(32) inline __m256i g_maskTable[32];
+#endif
 
 typedef unsigned int suffix;
 typedef unsigned int t_index;
@@ -262,6 +264,12 @@ inline void initWorker(workerData &worker) {
     temp[i] = _mm256_insertf128_si256(temp[i], upper_part, 1); // Set upper 128 bits
   }
   memcpy(&worker.maskTable[0], temp, 32*sizeof(__m256i));
+  printf("worker.maskTable\n");
+  alignas(16) uint32_t v[8];
+  for(int i = 0; i < 32; i++) {
+    _mm256_storeu_si256((__m256i*)v, worker.maskTable[i]);
+    printf("%02d v8_u32: %x %x %x %x %x %x %x %x\n", i, v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]);
+  }
 
   #endif
   std::copy(branchedOps_global.begin(), branchedOps_global.end(), worker.branchedOps);


### PR DESCRIPTION
The changes to miner.cpp is probably the interesting bit.
The #pragma clang optimize off/on that surround the new `initMaskTable` method basically fix the failing tests AFAICT.
